### PR TITLE
Make sona exit itself if parent goes away

### DIFF
--- a/cmd/sona/commands.go
+++ b/cmd/sona/commands.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/thewh1teagle/sona/internal/audio"
 	"github.com/thewh1teagle/sona/internal/server"
 	"github.com/thewh1teagle/sona/internal/whisper"
+	"github.com/thewh1teagle/sona/parent"
 )
 
 type app struct {
@@ -98,12 +100,27 @@ func (a *app) newTranscribeCommand() *cobra.Command {
 func (a *app) newServeCommand() *cobra.Command {
 	var host string
 	var port int
+	var isparent bool
 
 	cmd := &cobra.Command{
 		Use:   "serve [model.bin]",
 		Short: "Start a transcription runner",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if isparent {
+				go func() {
+					for {
+						if parent.ParentExited() {
+							fmt.Println("Parent process exited")
+							os.Exit(0)
+						}
+
+						time.Sleep(1 * time.Second)
+					}
+				}()
+			}
+
 			audio.SetVerbose(a.verbose)
 			whisper.SetVerbose(a.verbose)
 
@@ -124,6 +141,7 @@ func (a *app) newServeCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "host to bind to")
 	cmd.Flags().IntVarP(&port, "port", "p", 0, "port to listen on (0 = auto-assign)")
+	cmd.Flags().BoolVar(&isparent, "parent", false, "Parent monitoring")
 	return cmd
 }
 

--- a/parent/parent.go
+++ b/parent/parent.go
@@ -1,0 +1,12 @@
+package parent
+
+import (
+	"os"
+)
+
+var parentPID = os.Getppid()
+
+// ParentExited returns true if the original parent process is gone.
+func ParentExited() bool {
+	return !processExists(parentPID)
+}

--- a/parent/parent_unix.go
+++ b/parent/parent_unix.go
@@ -1,0 +1,10 @@
+//go:build linux || darwin
+
+package parent
+
+import "syscall"
+
+func processExists(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil
+}

--- a/parent/parent_windows.go
+++ b/parent/parent_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package parent
+
+import (
+	"syscall"
+)
+
+func processExists(pid int) bool {
+	handle, err := syscall.OpenProcess(syscall.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(handle)
+
+	var code uint32
+	err = syscall.GetExitCodeProcess(handle, &code)
+	if err != nil {
+		return false
+	}
+
+	const STILL_ACTIVE = 259
+	return code == STILL_ACTIVE
+}


### PR DESCRIPTION
Setup:

```
$ go build
$ bash
$ echo $$
170372
$ ./sona serve --parent
{"commit":"dev","port":33679,"status":"ready","version":"dev"}
2026/03/12 21:13:10 listening on 127.0.0.1:33679
```

Now: on another terminal:
```
$kill -SIGKILL 170372
```

On first terminal:
```
Killed
$ Parent process exited
```

Basically killing the parent bash of sona makes sona self-quit.

Should work on every OS.