### PR TITLE
feat: exit with parent process

### DIFF
--- a/cmd/sona/commands.go
+++ b/cmd/sona/commands.go
@@ -98,6 +98,7 @@ func (a *app) newTranscribeCommand() *cobra.Command {
 func (a *app) newServeCommand() *cobra.Command {
 	var host string
 	var port int
+	var exitWithParent bool
 
 	cmd := &cobra.Command{
 		Use:   "serve [model.bin]",
@@ -106,6 +107,10 @@ func (a *app) newServeCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			audio.SetVerbose(a.verbose)
 			whisper.SetVerbose(a.verbose)
+
+			if exitWithParent {
+				go watchParent()
+			}
 
 			s := server.New(a.verbose)
 			s.Version = version
@@ -124,6 +129,7 @@ func (a *app) newServeCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "host to bind to")
 	cmd.Flags().IntVarP(&port, "port", "p", 0, "port to listen on (0 = auto-assign)")
+	cmd.Flags().BoolVar(&exitWithParent, "exit-with-parent", true, "exit when the parent process exits")
 	return cmd
 }
 

--- a/cmd/sona/parent.go
+++ b/cmd/sona/parent.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+	"time"
+)
+
+func watchParent() {
+	ppid := os.Getppid()
+	for range time.Tick(time.Second) {
+		if os.Getppid() != ppid {
+			os.Exit(0)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--exit-with-parent` flag to the `serve` command (defaults to `true`)
- Spawns a goroutine that polls `os.Getppid()` every second and calls `os.Exit(0)` if the parent process dies
- Prevents sona from becoming an orphan process when the parent (e.g. Vibe) exits unexpectedly
- Can be disabled with `--exit-with-parent=false` for standalone usage

## Related

- #15
- https://github.com/thewh1teagle/vibe/issues/1006

## Test plan

- [ ] Start sona with `sona serve --port 0`, kill the parent process, verify sona exits
- [ ] Start sona with `sona serve --port 0 --exit-with-parent=false`, kill the parent, verify sona stays alive
- [ ] Verify normal shutdown still works (SIGTERM/SIGINT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)