### PR TITLE
feat: expose per-segment no_speech_prob in transcription responses

### DIFF
--- a/internal/server/api_handlers.go
+++ b/internal/server/api_handlers.go
@@ -308,10 +308,11 @@ func (s *Server) handleStreamingTranscription(w http.ResponseWriter, r *http.Req
 		},
 		OnSegment: func(seg whisper.Segment) {
 			event := map[string]any{
-				"type":  "segment",
-				"start": csToSeconds(seg.Start),
-				"end":   csToSeconds(seg.End),
-				"text":  seg.Text,
+				"type":           "segment",
+				"start":          csToSeconds(seg.Start),
+				"end":            csToSeconds(seg.End),
+				"text":           seg.Text,
+				"no_speech_prob": seg.NoSpeechProb,
 			}
 			if diarSegments != nil {
 				if sp := matchSpeaker(csToSeconds(seg.Start), csToSeconds(seg.End), diarSegments); sp >= 0 {

--- a/internal/server/format.go
+++ b/internal/server/format.go
@@ -73,10 +73,11 @@ func formatVTT(segments []whisper.Segment) string {
 
 // verboseSegment is the JSON representation of a segment in verbose_json format.
 type verboseSegment struct {
-	Start   float64 `json:"start"`
-	End     float64 `json:"end"`
-	Text    string  `json:"text"`
-	Speaker *int    `json:"speaker,omitempty"`
+	Start        float64 `json:"start"`
+	End          float64 `json:"end"`
+	Text         string  `json:"text"`
+	Speaker      *int    `json:"speaker,omitempty"`
+	NoSpeechProb float32 `json:"no_speech_prob"`
 }
 
 // verboseJSON is the response body for response_format=verbose_json.
@@ -93,9 +94,10 @@ func buildVerboseJSON(segments []whisper.Segment, diarSegments []diarize.Segment
 	vSegs := make([]verboseSegment, len(segments))
 	for i, seg := range segments {
 		vSegs[i] = verboseSegment{
-			Start: csToSeconds(seg.Start),
-			End:   csToSeconds(seg.End),
-			Text:  seg.Text,
+			Start:        csToSeconds(seg.Start),
+			End:          csToSeconds(seg.End),
+			Text:         seg.Text,
+			NoSpeechProb: seg.NoSpeechProb,
 		}
 		if diarSegments != nil {
 			if sp := matchSpeaker(csToSeconds(seg.Start), csToSeconds(seg.End), diarSegments); sp >= 0 {

--- a/internal/whisper/whisper.go
+++ b/internal/whisper/whisper.go
@@ -28,9 +28,10 @@ type TranscribeOptions struct {
 
 // Segment represents a transcribed text segment with timestamps.
 type Segment struct {
-	Start int64 // start time in centiseconds (10ms units)
-	End   int64 // end time in centiseconds (10ms units)
-	Text  string
+	Start        int64   // start time in centiseconds (10ms units)
+	End          int64   // end time in centiseconds (10ms units)
+	Text         string
+	NoSpeechProb float32 // whisper per-segment "non-speech" probability, in [0.0, 1.0]
 }
 
 // TranscribeResult holds the output of a transcription.

--- a/internal/whisper/whisper_callbacks_cgo.go
+++ b/internal/whisper/whisper_callbacks_cgo.go
@@ -30,9 +30,10 @@ func sonaGoSegmentCB(handle uintptr, ctxPtr unsafe.Pointer, nNew int32) {
 		nSegments := int(C.whisper_full_n_segments(ctx))
 		for i := nSegments - int(nNew); i < nSegments; i++ {
 			seg := Segment{
-				Start: int64(C.whisper_full_get_segment_t0(ctx, C.int(i))),
-				End:   int64(C.whisper_full_get_segment_t1(ctx, C.int(i))),
-				Text:  C.GoString(C.whisper_full_get_segment_text(ctx, C.int(i))),
+				Start:        int64(C.whisper_full_get_segment_t0(ctx, C.int(i))),
+				End:          int64(C.whisper_full_get_segment_t1(ctx, C.int(i))),
+				Text:         C.GoString(C.whisper_full_get_segment_text(ctx, C.int(i))),
+				NoSpeechProb: float32(C.whisper_full_get_segment_no_speech_prob(ctx, C.int(i))),
 			}
 			cb.OnSegment(seg)
 		}

--- a/internal/whisper/whisper_cgo.go
+++ b/internal/whisper/whisper_cgo.go
@@ -153,9 +153,10 @@ func collectSegments(ctx *C.struct_whisper_context) []Segment {
 	segments := make([]Segment, nSegments)
 	for i := 0; i < nSegments; i++ {
 		segments[i] = Segment{
-			Start: int64(C.whisper_full_get_segment_t0(ctx, C.int(i))),
-			End:   int64(C.whisper_full_get_segment_t1(ctx, C.int(i))),
-			Text:  C.GoString(C.whisper_full_get_segment_text(ctx, C.int(i))),
+			Start:        int64(C.whisper_full_get_segment_t0(ctx, C.int(i))),
+			End:          int64(C.whisper_full_get_segment_t1(ctx, C.int(i))),
+			Text:         C.GoString(C.whisper_full_get_segment_text(ctx, C.int(i))),
+			NoSpeechProb: float32(C.whisper_full_get_segment_no_speech_prob(ctx, C.int(i))),
 		}
 	}
 	return segments


### PR DESCRIPTION
## Motivation

Applications building UIs on top of sona (transcript editors, subtitling tools, accessibility frontends) often need to flag uncertain segments to the user — for example to highlight passages that may be transcription errors. whisper.cpp computes a per-segment "no-speech" probability internally (`whisper_full_get_segment_no_speech_prob`), and `1.0 - no_speech_prob` makes a usable per-segment confidence score. Today sona drops this value before it reaches the API surface.

This PR forwards that value through to API consumers without changing any existing behavior.

## Change

The `whisper.Segment` Go struct gains a `NoSpeechProb float32` field, populated in both batch (`collectSegments`) and streaming (`sonaGoSegmentCB`) code paths via `whisper_full_get_segment_no_speech_prob` from the bundled `whisper.h`.

The HTTP API forwards this value:
- ndjson streaming (`stream=true`): the per-segment event gains a `"no_speech_prob": <float>` field.
- `verbose_json`: each entry in `segments` gains a `"no_speech_prob": <float>` field.

Other formats (`text`, `srt`, `vtt`, plain `json`) are unchanged.

## Backward compatibility

Fully backward-compatible:
- existing clients that don't read `no_speech_prob` are unaffected (additive JSON field);
- the Go `Segment` struct gains a field but the zero value (`0.0`) is meaningful (≈ "speech is certain"), so callers that build segments by hand remain valid;
- no existing struct field is renamed or removed;
- `format_test.go::TestBuildVerboseJSON` continues to pass unchanged.

## Files touched

- `internal/whisper/whisper.go` — add `NoSpeechProb` to `Segment`
- `internal/whisper/whisper_cgo.go` — populate it in `collectSegments`
- `internal/whisper/whisper_callbacks_cgo.go` — populate it in `sonaGoSegmentCB`
- `internal/server/api_handlers.go` — emit it in the streaming ndjson event
- `internal/server/format.go` — emit it in `verbose_json`

## Use case

Used by [VS Transcript](https://github.com/jejeasterix/vs-transcript-app), a Vibe-derived desktop application for French gendarmerie hearing transcripts, to highlight low-confidence segments in the editor (red < 40 %, yellow < 60 %).

## Testing notes

I have not been able to compile the patched binary locally (the build requires Go + CGO + a C toolchain, which I don't have set up on Windows). The patch is mechanical and small, so reviewing the diff should be straightforward; any maintainer who builds it locally would confirm the streaming `no_speech_prob` values look reasonable on real audio. Happy to iterate if a different field name or a different code path is preferred.
