### PR TITLE
Reduce model memory and delay-load Vulkan on Windows

### DIFF
--- a/crates/sona/build.rs
+++ b/crates/sona/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let is_windows_msvc = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc");
+
+    if is_windows_msvc {
+        println!("cargo:rustc-link-lib=delayimp");
+        println!("cargo:rustc-link-arg-bin=sona=/DELAYLOAD:vulkan-1.dll");
+    }
+}

--- a/crates/whisper-rs/src/context.rs
+++ b/crates/whisper-rs/src/context.rs
@@ -11,7 +11,6 @@ use crate::{ffi, platform};
 #[derive(Debug)]
 pub struct Context {
     ctx: *mut ffi::whisper_context,
-    model: Vec<u8>,
 }
 
 impl Context {
@@ -42,7 +41,10 @@ impl Context {
             return Err(Error::LoadModel(PathBuf::from(path)));
         }
 
-        Ok(Self { ctx, model })
+        // whisper.cpp has finished reading the input buffer once initialization
+        // returns, so keeping the complete model file resident would only
+        // duplicate its memory for the lifetime of the context.
+        Ok(Self { ctx })
     }
 
     pub fn transcribe(
@@ -107,7 +109,6 @@ impl Drop for Context {
             unsafe { ffi::whisper_free(self.ctx) };
             self.ctx = ptr::null_mut();
         }
-        let _ = self.model.len();
     }
 }
 


### PR DESCRIPTION
## What changed

- Release the temporary model byte buffer after whisper.cpp initialization instead of retaining a full duplicate for the context lifetime.
- Delay-load `vulkan-1.dll` in the Windows MSVC Sona binary so machines without Vulkan can reach the CPU fallback path.

## Why

Vibe analytics show increased Sona model/process failures and a Windows startup EOF regression after the Rust Sona rollout. The previous Windows build intentionally delay-loaded Vulkan, while the MSVC build linked it as a startup dependency.

## Validation

- `cargo check --workspace`
- `cargo test -p whisper-rs`
- Real JFK transcription with a local 1.5 GB model
- Verified MSVC build-script linker output