### PR TITLE
Add model metadata and Nemotron sentence segments

### DIFF
--- a/crates/nemotron-rs/src/lib.rs
+++ b/crates/nemotron-rs/src/lib.rs
@@ -6,6 +6,7 @@ mod mel;
 mod model;
 mod ops;
 mod runtime;
+mod segment;
 mod tokenizer;
 
 pub use decoder::Token;

--- a/crates/nemotron-rs/src/model.rs
+++ b/crates/nemotron-rs/src/model.rs
@@ -14,6 +14,7 @@ pub struct ModelInfo {
     pub variant: String,
     pub head_kind: String,
     pub languages: Vec<String>,
+    pub language_detection: bool,
     pub tensor_count: usize,
     pub encoder_layers: i32,
     pub encoder_dimension: i32,
@@ -81,6 +82,32 @@ impl Drop for DeviceWeights {
 unsafe impl Send for Model {}
 
 impl Model {
+    /// Read model metadata without allocating or uploading tensor data.
+    pub fn metadata(path: impl AsRef<Path>) -> Result<ModelInfo> {
+        let path = CString::new(path.as_ref().to_string_lossy().as_bytes()).map_err(|_| Error::InvalidPath)?;
+        let mut weights = ptr::null_mut();
+        let gguf = unsafe {
+            sys::gguf_init_from_file(
+                path.as_ptr(),
+                sys::gguf_init_params {
+                    no_alloc: true,
+                    ctx: &mut weights,
+                },
+            )
+        };
+        if gguf.is_null() {
+            return Err(Error::Load(path.to_string_lossy().into_owned()));
+        }
+        let result = unsafe { read_info(gguf) };
+        unsafe {
+            if !weights.is_null() {
+                sys::ggml_free(weights);
+            }
+            sys::gguf_free(gguf);
+        }
+        result
+    }
+
     pub fn load(path: impl AsRef<Path>) -> Result<Self> {
         let path = CString::new(path.as_ref().to_string_lossy().as_bytes()).map_err(|_| Error::InvalidPath)?;
         let mut weights = ptr::null_mut();
@@ -203,8 +230,10 @@ impl Model {
                 transcription.text = self.tokenizer.decode_clean(&ids);
             }
             last_frame = transcription.tokens.last().map(|token| token.frame).or(last_frame);
-            on_segment(&transcription);
-            result.segments.push(transcription);
+            for segment in crate::segment::split_sentences(transcription.tokens, &self.tokenizer) {
+                on_segment(&segment);
+                result.segments.push(segment);
+            }
         }
         Ok(result)
     }
@@ -452,6 +481,7 @@ unsafe fn read_info(ctx: *const sys::gguf_context) -> Result<ModelInfo> {
         variant: string(ctx, "stt.variant")?,
         head_kind: string(ctx, "stt.parakeet.head_kind")?,
         languages: strings(ctx, "general.languages")?,
+        language_detection: optional_bool(ctx, "stt.capability.lang_detect").unwrap_or(false),
         tensor_count: sys::gguf_get_n_tensors(ctx) as usize,
         encoder_layers: u32_value(ctx, "stt.parakeet.encoder.n_layers")? as i32,
         encoder_dimension: u32_value(ctx, "stt.parakeet.encoder.d_model")? as i32,
@@ -512,6 +542,12 @@ unsafe fn optional_u32(ctx: *const sys::gguf_context, name: &'static str) -> Opt
 
 unsafe fn bool_value(ctx: *const sys::gguf_context, name: &'static str) -> Result<bool> {
     Ok(sys::gguf_get_val_bool(ctx, key(ctx, name)?))
+}
+
+unsafe fn optional_bool(ctx: *const sys::gguf_context, name: &'static str) -> Option<bool> {
+    let c_name = CString::new(name).unwrap();
+    let id = sys::gguf_find_key(ctx, c_name.as_ptr());
+    (id >= 0).then(|| sys::gguf_get_val_bool(ctx, id))
 }
 
 unsafe fn read_prompts(ctx: *const sys::gguf_context) -> Result<(HashMap<String, usize>, usize)> {

--- a/crates/nemotron-rs/src/segment.rs
+++ b/crates/nemotron-rs/src/segment.rs
@@ -1,0 +1,72 @@
+use crate::{Token, Tokenizer, Transcription};
+
+pub(crate) fn split_sentences(tokens: Vec<Token>, tokenizer: &Tokenizer) -> Vec<Transcription> {
+    split_with(tokens, |slice| {
+        let ids = slice.iter().map(|token| token.id).collect::<Vec<_>>();
+        tokenizer.decode_clean(&ids)
+    })
+}
+
+fn split_with(tokens: Vec<Token>, decode: impl Fn(&[Token]) -> String) -> Vec<Transcription> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    for end in 1..=tokens.len() {
+        let text = decode(&tokens[start..end]);
+        if ends_sentence(&text) {
+            segments.push(Transcription {
+                text,
+                tokens: tokens[start..end].to_vec(),
+            });
+            start = end;
+        }
+    }
+    if start < tokens.len() {
+        let text = decode(&tokens[start..]);
+        if !text.is_empty() {
+            segments.push(Transcription {
+                text,
+                tokens: tokens[start..].to_vec(),
+            });
+        }
+    }
+    segments
+}
+
+fn ends_sentence(text: &str) -> bool {
+    matches!(text.trim_end().chars().last(), Some('.' | '?' | '!' | '。' | '？' | '！'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_on_sentence_punctuation_and_preserves_timestamps() {
+        let tokens = (0..5)
+            .map(|index| Token {
+                id: index as u32,
+                frame: index * 10,
+            })
+            .collect();
+        let pieces = ["Hello", " world.", "How", " are", " you?"];
+        let result = split_with(tokens, |slice| slice.iter().map(|token| pieces[token.id as usize]).collect());
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].text, "Hello world.");
+        assert_eq!(result[0].tokens.first().unwrap().frame, 0);
+        assert_eq!(result[0].tokens.last().unwrap().frame, 10);
+        assert_eq!(result[1].text, "How are you?");
+        assert_eq!(result[1].tokens.first().unwrap().frame, 20);
+        assert_eq!(result[1].tokens.last().unwrap().frame, 40);
+    }
+
+    #[test]
+    fn keeps_unpunctuated_remainder() {
+        let tokens = vec![Token { id: 0, frame: 4 }, Token { id: 1, frame: 8 }];
+        let pieces = ["still", " talking"];
+        let result = split_with(tokens, |slice| slice.iter().map(|token| pieces[token.id as usize]).collect());
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].text, "still talking");
+    }
+}

--- a/crates/sona/src/engine.rs
+++ b/crates/sona/src/engine.rs
@@ -4,6 +4,8 @@ use whisper_rs::{ContextOptions, Segment, StreamCallbacks, TranscribeOptions, Tr
 
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct EngineCapabilities {
+    pub engine: String,
+    pub requires_vad: bool,
     pub languages: Vec<String>,
     pub language_detection: bool,
     pub streaming: bool,
@@ -145,23 +147,31 @@ impl Engine {
 
     pub fn capabilities(&self) -> EngineCapabilities {
         match self {
-            Self::Whisper(_) => EngineCapabilities {
-                languages: whisper_rs::supported_languages(),
-                language_detection: true,
-                streaming: true,
-                translation: true,
-                timestamps: true,
-                text_prompts: true,
-            },
+            Self::Whisper(_) => whisper_capabilities(),
             Self::Nemotron { model, .. } => EngineCapabilities {
+                engine: "nemotron".to_string(),
+                requires_vad: true,
                 languages: model.info().languages.clone(),
-                language_detection: true,
+                language_detection: model.info().language_detection,
                 streaming: false,
                 translation: false,
                 timestamps: true,
                 text_prompts: false,
             },
         }
+    }
+}
+
+pub fn whisper_capabilities() -> EngineCapabilities {
+    EngineCapabilities {
+        engine: "whisper".to_string(),
+        requires_vad: false,
+        languages: whisper_rs::supported_languages(),
+        language_detection: true,
+        streaming: true,
+        translation: true,
+        timestamps: true,
+        text_prompts: true,
     }
 }
 

--- a/crates/sona/src/server/mod.rs
+++ b/crates/sona/src/server/mod.rs
@@ -68,6 +68,7 @@ impl ServerState {
         routes::health::ready,
         routes::skill::skill,
         routes::models::load_model,
+        routes::models::model_metadata,
         routes::models::unload_model,
         routes::models::list_models,
         routes::transcriptions::transcriptions
@@ -77,6 +78,8 @@ impl ServerState {
         ReadyResponse,
         ModelLoadRequest,
         ModelStatusResponse,
+        ModelMetadataRequest,
+        ModelMetadataResponse,
         ErrorResponse,
         ModelListResponse,
         ModelInfo,
@@ -106,6 +109,7 @@ pub async fn serve(host: String, port: u16, initial_model: Option<String>, confi
         .route("/ready", get(routes::health::ready))
         .route("/skill", get(routes::skill::skill))
         .route("/v1/models/load", post(routes::models::load_model))
+        .route("/v1/models/metadata", post(routes::models::model_metadata))
         .route(
             "/v1/models",
             delete(routes::models::unload_model).get(routes::models::list_models),
@@ -183,6 +187,17 @@ pub(super) struct ModelLoadRequest {
 pub(super) struct ModelStatusResponse {
     status: &'static str,
     model: String,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub(super) struct ModelMetadataRequest {
+    path: String,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub(super) struct ModelMetadataResponse {
+    format: &'static str,
+    capabilities: crate::engine::EngineCapabilities,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/crates/sona/src/server/routes/models.rs
+++ b/crates/sona/src/server/routes/models.rs
@@ -5,7 +5,67 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 
-use crate::server::{error, AppState, ModelInfo, ModelListResponse, ModelLoadRequest, ModelStatusResponse};
+use crate::server::{
+    error, AppState, ModelInfo, ModelListResponse, ModelLoadRequest, ModelMetadataRequest, ModelMetadataResponse,
+    ModelStatusResponse,
+};
+
+#[utoipa::path(
+    post,
+    path = "/v1/models/metadata",
+    request_body = ModelMetadataRequest,
+    responses(
+        (status = 200, description = "Model metadata", body = ModelMetadataResponse),
+        (status = 400, description = "Unsupported or invalid model", body = crate::server::ErrorResponse)
+    )
+)]
+pub(in crate::server) async fn model_metadata(Json(request): Json<ModelMetadataRequest>) -> Response {
+    if request.path.trim().is_empty() {
+        return error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "request body must contain a model path",
+        );
+    }
+    let path = request.path.clone();
+    match tokio::task::spawn_blocking(move || nemotron_rs::Model::metadata(path)).await {
+        Ok(Ok(info)) if info.architecture == "parakeet" && info.head_kind == "rnnt" => (
+            StatusCode::OK,
+            Json(ModelMetadataResponse {
+                format: "gguf",
+                capabilities: crate::engine::EngineCapabilities {
+                    engine: "nemotron".to_string(),
+                    requires_vad: true,
+                    languages: info.languages,
+                    language_detection: info.language_detection,
+                    streaming: false,
+                    translation: false,
+                    timestamps: true,
+                    text_prompts: false,
+                },
+            }),
+        )
+            .into_response(),
+        Ok(Ok(info)) => error(
+            StatusCode::BAD_REQUEST,
+            "unsupported_model",
+            &format!("unsupported GGUF architecture '{}'", info.architecture),
+        ),
+        Ok(Err(_)) => (
+            StatusCode::OK,
+            Json(ModelMetadataResponse {
+                format: "whisper",
+                capabilities: crate::engine::whisper_capabilities(),
+            }),
+        )
+            .into_response(),
+        Err(err) => error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+            &format!("metadata task failed: {err}"),
+        ),
+    }
+}
 
 #[utoipa::path(
     post,


### PR DESCRIPTION
## Summary

- add a lightweight model metadata endpoint with engine capabilities and supported languages
- report Whisper capabilities without loading inference weights
- read Nemotron language-detection metadata from GGUF
- split Nemotron VAD inference chunks into punctuation-sized timestamped segments

## Why

Vibe needs model capabilities before transcription, and raw Nemotron VAD chunks currently surface as very large user-facing transcript segments.

## Validation

- `cargo test -p nemotron-rs -p sona`
- `cargo build -p sona --release`
- verified Whisper metadata returns 100 languages
- verified Nemotron metadata returns 32 locales and `requires_vad: true`
- verified `multi.wav` changes from 2 raw VAD segments to 8 punctuation-sized segments