### PR TITLE
Report Nemotron transcription progress

### DIFF
--- a/crates/nemotron-rs/src/model.rs
+++ b/crates/nemotron-rs/src/model.rs
@@ -199,7 +199,7 @@ impl Model {
     }
 
     pub fn transcribe(&self, vad: &mut vad_rs::Vad, samples: &[f32], language: &str) -> Result<LongFormTranscription> {
-        self.transcribe_with(vad, samples, language, || false, |_| {})
+        self.transcribe_with(vad, samples, language, || false, |_| {}, |_| {})
     }
 
     pub fn transcribe_with(
@@ -209,8 +209,16 @@ impl Model {
         language: &str,
         mut should_abort: impl FnMut() -> bool,
         mut on_segment: impl FnMut(&Transcription),
+        mut on_progress: impl FnMut(i32),
     ) -> Result<LongFormTranscription> {
         let ranges = vad.segments(samples).map_err(|error| Error::Vad(error.to_string()))?;
+        let total_samples = ranges
+            .iter()
+            .map(|range| range.end_sample.saturating_sub(range.start_sample))
+            .sum::<usize>()
+            .max(1);
+        let mut processed_samples = 0;
+        on_progress(0);
         let mut result = LongFormTranscription {
             segments: Vec::with_capacity(ranges.len()),
         };
@@ -234,6 +242,8 @@ impl Model {
                 on_segment(&segment);
                 result.segments.push(segment);
             }
+            processed_samples += range.end_sample.saturating_sub(range.start_sample);
+            on_progress(((processed_samples * 100) / total_samples).min(100) as i32);
         }
         Ok(result)
     }

--- a/crates/sona/src/engine.rs
+++ b/crates/sona/src/engine.rs
@@ -119,9 +119,6 @@ impl Engine {
                     mut on_segment,
                     mut should_abort,
                 } = callbacks;
-                if let Some(callback) = on_progress.as_mut() {
-                    callback(0);
-                }
                 let result = model.transcribe_with(
                     &mut vad.as_mut().unwrap().1,
                     samples,
@@ -134,10 +131,12 @@ impl Engine {
                             }
                         }
                     },
+                    |progress| {
+                        if let Some(callback) = on_progress.as_mut() {
+                            callback(progress);
+                        }
+                    },
                 )?;
-                if let Some(callback) = on_progress.as_mut() {
-                    callback(100);
-                }
                 Ok(TranscribeResult {
                     segments: result.segments.iter().filter_map(nemotron_segment).collect(),
                 })


### PR DESCRIPTION
## Summary

- report progress after each completed Nemotron VAD speech range
- weight progress by processed speech samples rather than chunk count
- forward those updates through Sona existing streaming progress events

## Why

Nemotron previously emitted only 0% and 100%, leaving long recordings apparently stuck at zero until completion.

## Validation

- `cargo test -p nemotron-rs -p sona`
- `cargo build -p sona --release`
- `multi.wav` emits progress 0, 38, 100