### PR TITLE
Fix parent exit and unload idle models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2116,7 @@ dependencies = [
  "diarize-rs",
  "futures-util",
  "hound",
+ "humantime",
  "libc",
  "nemotron-rs",
  "parakeet-rs 0.1.0",
@@ -2128,6 +2135,7 @@ dependencies = [
  "utoipa-swagger-ui",
  "vad-rs",
  "whisper-rs",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/sona/Cargo.toml
+++ b/crates/sona/Cargo.toml
@@ -20,9 +20,10 @@ diarize-rs = { path = "../diarize-rs", optional = true }
 anyhow = "1"
 axum = { version = "0.8", features = ["multipart"] }
 bytes = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 futures-util = "0.3"
 hound = "3.5"
+humantime = "2"
 libc = "0.2"
 reqwest = { version = "0.12", features = ["stream"] }
 serde = { version = "1", features = ["derive"] }
@@ -45,6 +46,16 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = "5"
 utoipa-axum = "0.2"
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Threading",
+] }
 
 [features]
 default = ["diarize"]

--- a/crates/sona/src/cli.rs
+++ b/crates/sona/src/cli.rs
@@ -64,6 +64,8 @@ enum Command {
         port: u16,
         #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
         exit_with_parent: bool,
+        #[arg(long, env = "SONA_UNLOAD_TIMEOUT", default_value = "0")]
+        unload_timeout: crate::server::unload_timeout::UnloadTimeout,
     },
     Pull {
         url: String,
@@ -149,11 +151,12 @@ pub async fn run() -> anyhow::Result<()> {
             host,
             port,
             exit_with_parent,
+            unload_timeout,
         } => {
             if exit_with_parent {
-                watch_parent();
+                crate::parent::watch();
             }
-            server::serve(host, port, model, config).await
+            server::serve(host, port, model, unload_timeout, config).await
         }
         Command::Pull { url, output } => pull::pull_file(&url, output.as_deref()).await,
         Command::Devices => devices_command(config),
@@ -236,17 +239,4 @@ struct TranscribeArgs {
     best_of: i32,
     beam_size: i32,
     gpu_device: i32,
-}
-
-fn watch_parent() {
-    #[cfg(unix)]
-    {
-        let parent = unsafe { libc::getppid() };
-        std::thread::spawn(move || loop {
-            std::thread::sleep(std::time::Duration::from_secs(1));
-            if unsafe { libc::getppid() } != parent {
-                std::process::exit(0);
-            }
-        });
-    }
 }

--- a/crates/sona/src/main.rs
+++ b/crates/sona/src/main.rs
@@ -1,6 +1,7 @@
 mod audio;
 mod cli;
 mod engine;
+mod parent;
 mod pull;
 mod server;
 

--- a/crates/sona/src/parent.rs
+++ b/crates/sona/src/parent.rs
@@ -1,0 +1,92 @@
+pub fn watch() {
+    #[cfg(unix)]
+    {
+        let parent = unsafe { libc::getppid() };
+        std::thread::spawn(move || loop {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            if unsafe { libc::getppid() } != parent {
+                std::process::exit(0);
+            }
+        });
+    }
+
+    #[cfg(windows)]
+    std::thread::spawn(windows::watch_parent);
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::io;
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, WAIT_FAILED, WAIT_OBJECT_0};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentProcessId, OpenProcess, WaitForSingleObject, INFINITE, PROCESS_SYNCHRONIZE,
+    };
+
+    pub(super) fn watch_parent() {
+        let parent_pid = match parent_process_id() {
+            Ok(parent_pid) => parent_pid,
+            Err(error) => {
+                eprintln!("warning: failed to identify parent process: {error}");
+                return;
+            }
+        };
+
+        let parent = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, 0, parent_pid) };
+        if parent.is_null() {
+            // The parent most likely exited between taking the snapshot and
+            // opening its handle. Honor --exit-with-parent in that race.
+            let error = io::Error::last_os_error();
+            eprintln!("warning: failed to open parent process {parent_pid}: {error}");
+            std::process::exit(0);
+        }
+
+        let result = unsafe { WaitForSingleObject(parent, INFINITE) };
+        unsafe {
+            CloseHandle(parent);
+        }
+        match result {
+            WAIT_OBJECT_0 => std::process::exit(0),
+            WAIT_FAILED => eprintln!(
+                "warning: failed while waiting for parent process {parent_pid}: {}",
+                io::Error::last_os_error()
+            ),
+            result => eprintln!("warning: unexpected result while waiting for parent process {parent_pid}: {result}"),
+        }
+    }
+
+    fn parent_process_id() -> io::Result<u32> {
+        let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+        if snapshot == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+
+        let current_pid = unsafe { GetCurrentProcessId() };
+        let mut entry = PROCESSENTRY32W {
+            dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+            ..Default::default()
+        };
+
+        let result = if unsafe { Process32FirstW(snapshot, &mut entry) } == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            loop {
+                if entry.th32ProcessID == current_pid {
+                    break Ok(entry.th32ParentProcessID);
+                }
+                if unsafe { Process32NextW(snapshot, &mut entry) } == 0 {
+                    break Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "current process missing from snapshot",
+                    ));
+                }
+            }
+        };
+        unsafe {
+            CloseHandle(snapshot);
+        }
+        result
+    }
+}

--- a/crates/sona/src/server/mod.rs
+++ b/crates/sona/src/server/mod.rs
@@ -4,6 +4,7 @@ mod format;
 mod routes;
 mod stream;
 mod transcription;
+pub(crate) mod unload_timeout;
 
 use std::net::SocketAddr;
 use std::path::Path;
@@ -27,6 +28,7 @@ const MAX_UPLOAD_SIZE: usize = 15 << 30;
 #[derive(Clone)]
 pub(super) struct AppState {
     inner: Arc<Mutex<ServerState>>,
+    unload_timeout: unload_timeout::UnloadTimeoutRuntime,
     config: AppConfig,
 }
 
@@ -34,6 +36,8 @@ pub(super) struct ServerState {
     ctx: Option<Engine>,
     model_name: String,
     model_path: String,
+    gpu_device: i32,
+    no_gpu: bool,
 }
 
 impl ServerState {
@@ -42,14 +46,28 @@ impl ServerState {
             ctx: None,
             model_name: String::new(),
             model_path: String::new(),
+            gpu_device: -1,
+            no_gpu: false,
         }
     }
 
-    fn load_model(&mut self, path: &str, gpu_device: i32, no_gpu: bool) -> anyhow::Result<()> {
-        self.ctx = None;
+    fn load_model(&mut self, path: &str, gpu_device: i32, no_gpu: Option<bool>) -> anyhow::Result<()> {
+        let matches_loaded_model = self.ctx.is_some()
+            && self.model_path == path
+            && self.gpu_device == gpu_device
+            && no_gpu.is_none_or(|requested| requested == self.no_gpu);
+        if matches_loaded_model {
+            tracing::debug!("model already loaded, skipping");
+            return Ok(());
+        }
+
+        self.unload_model();
+        let no_gpu = no_gpu.unwrap_or(false);
         let ctx = Engine::load(path, ContextOptions { gpu_device, no_gpu })?;
         self.model_name = Path::new(path).file_name().unwrap_or_default().to_string_lossy().into_owned();
         self.model_path = path.to_string();
+        self.gpu_device = gpu_device;
+        self.no_gpu = no_gpu;
         self.ctx = Some(ctx);
         Ok(())
     }
@@ -58,6 +76,8 @@ impl ServerState {
         self.ctx = None;
         self.model_name.clear();
         self.model_path.clear();
+        self.gpu_device = -1;
+        self.no_gpu = false;
     }
 }
 
@@ -92,15 +112,23 @@ impl ServerState {
 )]
 struct ApiDoc;
 
-pub async fn serve(host: String, port: u16, initial_model: Option<String>, config: AppConfig) -> anyhow::Result<()> {
+pub async fn serve(
+    host: String,
+    port: u16,
+    initial_model: Option<String>,
+    unload_timeout: unload_timeout::UnloadTimeout,
+    config: AppConfig,
+) -> anyhow::Result<()> {
     whisper_rs::set_verbose(config.verbose());
     let mut server_state = ServerState::new();
     if let Some(model) = initial_model.as_deref() {
-        server_state.load_model(model, -1, false)?;
+        server_state.load_model(model, -1, Some(false))?;
     }
 
+    let inner = Arc::new(Mutex::new(server_state));
     let state = AppState {
-        inner: Arc::new(Mutex::new(server_state)),
+        unload_timeout: unload_timeout::UnloadTimeoutRuntime::start(unload_timeout, Arc::clone(&inner)),
+        inner,
         config,
     };
     let ready_config = state.config;

--- a/crates/sona/src/server/routes/models.rs
+++ b/crates/sona/src/server/routes/models.rs
@@ -100,14 +100,14 @@ pub(in crate::server) async fn load_model(State(state): State<AppState>, Json(re
         );
     }
 
-    let mut guard = state.inner.lock().await;
+    let mut model = state.unload_timeout.acquire(state.inner.clone()).await;
     let gpu_device = request.gpu_device.unwrap_or(-1);
-    match guard.load_model(&request.path, gpu_device, request.no_gpu.unwrap_or(false)) {
+    match model.load_model(&request.path, gpu_device, request.no_gpu) {
         Ok(()) => (
             StatusCode::OK,
             Json(ModelStatusResponse {
                 status: "loaded",
-                model: guard.model_name.clone(),
+                model: model.model_name.clone(),
             }),
         )
             .into_response(),

--- a/crates/sona/src/server/routes/transcriptions.rs
+++ b/crates/sona/src/server/routes/transcriptions.rs
@@ -17,12 +17,19 @@ use crate::server::{error, AppState, MAX_UPLOAD_SIZE};
         (status = 503, description = "No model loaded", body = crate::server::ErrorResponse)
     )
 )]
-pub(in crate::server) async fn transcriptions(
-    State(state): State<AppState>,
-    multipart: Multipart,
-) -> Response {
+pub(in crate::server) async fn transcriptions(State(state): State<AppState>, multipart: Multipart) -> Response {
+    let model = match state.unload_timeout.try_acquire(state.inner.clone()) {
+        Ok(model) => model,
+        Err(_) => {
+            return error(
+                StatusCode::TOO_MANY_REQUESTS,
+                "busy",
+                "server is busy with another transcription",
+            );
+        }
+    };
     match parse_multipart(multipart).await {
-        Ok(request) => match crate::server::transcription::transcribe(state, request).await {
+        Ok(request) => match crate::server::transcription::transcribe(state.config, model, request).await {
             Ok(response) => response,
             Err(response) => response,
         },
@@ -64,13 +71,7 @@ async fn parse_multipart(mut multipart: Multipart) -> Result<TranscriptionReques
         }
     }
 
-    let file = file.ok_or_else(|| {
-        error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request",
-            "missing or invalid 'file' field",
-        )
-    })?;
+    let file = file.ok_or_else(|| error(StatusCode::BAD_REQUEST, "invalid_request", "missing or invalid 'file' field"))?;
 
     Ok(TranscriptionRequest { file, form })
 }

--- a/crates/sona/src/server/stream.rs
+++ b/crates/sona/src/server/stream.rs
@@ -8,33 +8,29 @@ use axum::response::{IntoResponse, Response};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use whisper_rs::StreamCallbacks;
 
+use crate::cli::AppConfig;
 use crate::server::diarization;
 use crate::server::transcription::build_options;
-use crate::server::{error, format, AppState};
+use crate::server::unload_timeout::ModelLease;
+use crate::server::{error, format};
 
 pub(super) fn stream_transcription(
-    state: AppState,
+    config: AppConfig,
+    mut model: ModelLease,
     samples: Vec<f32>,
     form: HashMap<String, String>,
     stable_timestamps: bool,
     vad_model_path: Option<String>,
     diar_segments: Vec<diarization::Segment>,
 ) -> Result<Response, Box<Response>> {
-    let mut guard = state.inner.clone().try_lock_owned().map_err(|_| {
-        Box::new(error(
-            StatusCode::TOO_MANY_REQUESTS,
-            "busy",
-            "server is busy with another transcription",
-        ))
-    })?;
-    if guard.ctx.is_none() {
+    if model.ctx.is_none() {
         return Err(Box::new(error(
             StatusCode::SERVICE_UNAVAILABLE,
             "no_model",
             "no model loaded",
         )));
     }
-    if guard.ctx.as_ref().is_some_and(|ctx| ctx.requires_vad()) && vad_model_path.is_none() {
+    if model.ctx.as_ref().is_some_and(|ctx| ctx.requires_vad()) && vad_model_path.is_none() {
         return Err(Box::new(error(
             StatusCode::BAD_REQUEST,
             "invalid_request",
@@ -42,14 +38,8 @@ pub(super) fn stream_transcription(
         )));
     }
 
-    let opts = build_options(
-        &form,
-        state.config.verbose(),
-        stable_timestamps,
-        vad_model_path,
-    );
-    let (tx, rx) =
-        tokio::sync::mpsc::unbounded_channel::<Result<bytes::Bytes, std::convert::Infallible>>();
+    let opts = build_options(&form, config.verbose(), stable_timestamps, vad_model_path);
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Result<bytes::Bytes, std::convert::Infallible>>();
     let aborted = Arc::new(AtomicBool::new(false));
     let abort_for_progress = Arc::clone(&aborted);
     let abort_for_segment = Arc::clone(&aborted);
@@ -60,7 +50,7 @@ pub(super) fn stream_transcription(
     let segment_diar_segments = diar_segments.clone();
 
     tokio::task::spawn_blocking(move || {
-        let Some(ctx) = guard.ctx.as_mut() else {
+        let Some(ctx) = model.ctx.as_mut() else {
             let _ = send_event(
                 &final_tx,
                 serde_json::json!({
@@ -98,8 +88,7 @@ pub(super) fn stream_transcription(
                         "text": segment.text,
                         "no_speech_prob": segment.no_speech_prob,
                     });
-                    if let Some(speaker) = format::match_speaker(start, end, &segment_diar_segments)
-                    {
+                    if let Some(speaker) = format::match_speaker(start, end, &segment_diar_segments) {
                         event["speaker"] = serde_json::json!(speaker);
                     }
                     if send_event(&segment_tx, event).is_err() {

--- a/crates/sona/src/server/transcription.rs
+++ b/crates/sona/src/server/transcription.rs
@@ -6,10 +6,12 @@ use axum::Json;
 use whisper_rs::TranscribeOptions;
 
 use crate::audio;
+use crate::cli::AppConfig;
 use crate::server::diarization;
 use crate::server::form::FormValues;
 use crate::server::stream::stream_transcription;
-use crate::server::{error, format, AppState, TextResponse};
+use crate::server::unload_timeout::ModelLease;
+use crate::server::{error, format, TextResponse};
 
 pub(super) struct TranscriptionRequest {
     pub file: Vec<u8>,
@@ -17,18 +19,12 @@ pub(super) struct TranscriptionRequest {
 }
 
 pub(super) async fn transcribe(
-    state: AppState,
+    config: AppConfig,
+    mut model: ModelLease,
     request: TranscriptionRequest,
 ) -> Result<Response, Response> {
     let TranscriptionRequest { file, form } = request;
-    let (
-        diarize_model,
-        enhance_audio,
-        stable_timestamps,
-        vad_model_path,
-        stream,
-        response_format,
-    ) = {
+    let (diarize_model, enhance_audio, stable_timestamps, vad_model_path, stream, response_format) = {
         let values = FormValues::new(&form);
         (
             values.string("diarize_model"),
@@ -41,7 +37,7 @@ pub(super) async fn transcribe(
     };
     let audio_options = audio::ReadOptions {
         enhance_audio,
-        verbose: state.config.verbose(),
+        verbose: config.verbose(),
     };
     let samples = audio::read_bytes_with_options(file, audio_options).map_err(|err| {
         error(
@@ -53,9 +49,7 @@ pub(super) async fn transcribe(
 
     let diar_segments = diarize_model
         .as_deref()
-        .map_or_else(Vec::new, |model_path| {
-            diarization::diarize(model_path, &samples)
-        });
+        .map_or_else(Vec::new, |model_path| diarization::diarize(model_path, &samples));
 
     if stable_timestamps && vad_model_path.is_none() {
         return Err(error(
@@ -66,32 +60,15 @@ pub(super) async fn transcribe(
     }
 
     if stream {
-        return stream_transcription(
-            state,
-            samples,
-            form,
-            stable_timestamps,
-            vad_model_path,
-            diar_segments,
-        )
-        .map_err(|err| *err);
+        return stream_transcription(config, model, samples, form, stable_timestamps, vad_model_path, diar_segments)
+            .map_err(|err| *err);
     }
 
-    let mut guard = state.inner.try_lock().map_err(|_| {
-        error(
-            StatusCode::TOO_MANY_REQUESTS,
-            "busy",
-            "server is busy with another transcription",
-        )
-    })?;
-    let verbose = state.config.verbose();
-    let ctx = guard.ctx.as_mut().ok_or_else(|| {
-        error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "no_model",
-            "no model loaded",
-        )
-    })?;
+    let verbose = config.verbose();
+    let ctx = model
+        .ctx
+        .as_mut()
+        .ok_or_else(|| error(StatusCode::SERVICE_UNAVAILABLE, "no_model", "no model loaded"))?;
 
     if ctx.requires_vad() && vad_model_path.is_none() {
         return Err(error(
@@ -131,9 +108,7 @@ pub(super) fn build_options(
         max_text_ctx: values.i32("max_text_ctx"),
         word_timestamps: values.bool("word_timestamps"),
         max_segment_len: values.i32("max_segment_len"),
-        sampling_greedy: form
-            .get("sampling_strategy")
-            .is_none_or(|strategy| strategy != "beam_search"),
+        sampling_greedy: form.get("sampling_strategy").is_none_or(|strategy| strategy != "beam_search"),
         best_of: values.i32("best_of"),
         beam_size: values.i32("beam_size"),
         stable_timestamps,
@@ -148,11 +123,7 @@ fn format_response(
 ) -> Response {
     match response_format {
         "verbose_json" => Json(format::build_verbose_json(result, diar_segments)).into_response(),
-        "text" => (
-            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
-            result.text(),
-        )
-            .into_response(),
+        "text" => ([(header::CONTENT_TYPE, "text/plain; charset=utf-8")], result.text()).into_response(),
         "srt" => (
             [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
             format::format_srt(&result.segments),
@@ -163,9 +134,6 @@ fn format_response(
             format::format_vtt(&result.segments),
         )
             .into_response(),
-        _ => Json(TextResponse {
-            text: result.text(),
-        })
-        .into_response(),
+        _ => Json(TextResponse { text: result.text() }).into_response(),
     }
 }

--- a/crates/sona/src/server/unload_timeout.rs
+++ b/crates/sona/src/server/unload_timeout.rs
@@ -1,0 +1,269 @@
+use std::str::FromStr;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use std::{ops::Deref, ops::DerefMut};
+
+use tokio::sync::{watch, Mutex, OwnedMutexGuard, TryLockError};
+use tokio::time::Instant;
+
+use super::ServerState;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnloadTimeout(Option<Duration>);
+
+impl UnloadTimeout {
+    fn timeout(self) -> Option<Duration> {
+        self.0
+    }
+}
+
+impl FromStr for UnloadTimeout {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value == "0" {
+            return Ok(Self(None));
+        }
+
+        let duration = humantime::parse_duration(value).map_err(|error| error.to_string())?;
+        if duration.is_zero() {
+            return Err("unload timeout must be greater than zero, or 0 to disable unloading".to_string());
+        }
+        Ok(Self(Some(duration)))
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct UnloadTimeoutRuntime {
+    timeout: Option<Duration>,
+    deadline: watch::Sender<Option<Instant>>,
+    state: Arc<StdMutex<ActivityState>>,
+}
+
+struct ActivityState {
+    active_requests: usize,
+    deadline: Option<Instant>,
+}
+
+struct DeadlineArm {
+    runtime: UnloadTimeoutRuntime,
+}
+
+impl Drop for DeadlineArm {
+    fn drop(&mut self) {
+        self.runtime.finish_request();
+    }
+}
+
+pub(super) struct ModelLease {
+    // Rust drops fields in declaration order: release exclusive model access
+    // first, then arm a fresh timeout from completion.
+    guard: OwnedMutexGuard<ServerState>,
+    _deadline_arm: DeadlineArm,
+}
+
+impl Deref for ModelLease {
+    type Target = ServerState;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl DerefMut for ModelLease {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}
+
+impl UnloadTimeoutRuntime {
+    pub(super) fn start(timeout: UnloadTimeout, state: Arc<Mutex<ServerState>>) -> Self {
+        let timeout = timeout.timeout();
+        let deadline = timeout.map(|duration| Instant::now() + duration);
+        let (deadline_tx, receiver) = watch::channel(deadline);
+        let runtime = Self {
+            timeout,
+            deadline: deadline_tx,
+            state: Arc::new(StdMutex::new(ActivityState {
+                active_requests: 0,
+                deadline,
+            })),
+        };
+        if runtime.timeout.is_some() {
+            tokio::spawn(run(runtime.clone(), receiver, state));
+        }
+        runtime
+    }
+
+    fn begin_request(&self) -> DeadlineArm {
+        if self.timeout.is_some() {
+            if let Ok(mut state) = self.state.lock() {
+                state.active_requests += 1;
+                state.deadline = None;
+            }
+            self.deadline.send_replace(None);
+        }
+        DeadlineArm { runtime: self.clone() }
+    }
+
+    pub(super) async fn acquire(&self, state: Arc<Mutex<ServerState>>) -> ModelLease {
+        let guard = state.lock_owned().await;
+        let activity = self.begin_request();
+        ModelLease {
+            guard,
+            _deadline_arm: activity,
+        }
+    }
+
+    pub(super) fn try_acquire(&self, state: Arc<Mutex<ServerState>>) -> Result<ModelLease, TryLockError> {
+        let guard = state.try_lock_owned()?;
+        let activity = self.begin_request();
+        Ok(ModelLease {
+            guard,
+            _deadline_arm: activity,
+        })
+    }
+
+    fn finish_request(&self) {
+        if let Some(timeout) = self.timeout {
+            let mut deadline = None;
+            if let Ok(mut state) = self.state.lock() {
+                state.active_requests = state.active_requests.saturating_sub(1);
+                if state.active_requests == 0 {
+                    deadline = Some(Instant::now() + timeout);
+                    state.deadline = deadline;
+                }
+            }
+            if deadline.is_some() {
+                self.deadline.send_replace(deadline);
+            }
+        }
+    }
+
+    fn can_unload(&self) -> bool {
+        if self.timeout.is_none() {
+            return false;
+        }
+        self.state
+            .lock()
+            .is_ok_and(|state| state.active_requests == 0 && state.deadline.is_some_and(|deadline| Instant::now() >= deadline))
+    }
+
+    async fn wait_until_expired(&self, receiver: &mut watch::Receiver<Option<Instant>>) -> bool {
+        if self.timeout.is_none() {
+            return false;
+        }
+
+        loop {
+            let deadline = *receiver.borrow_and_update();
+            match deadline {
+                Some(deadline) => {
+                    tokio::select! {
+                        _ = tokio::time::sleep_until(deadline) => return true,
+                        changed = receiver.changed() => {
+                            if changed.is_err() {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                None => {
+                    if receiver.changed().await.is_err() {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run(runtime: UnloadTimeoutRuntime, mut receiver: watch::Receiver<Option<Instant>>, state: Arc<Mutex<ServerState>>) {
+    while runtime.wait_until_expired(&mut receiver).await {
+        {
+            let mut state = state.lock().await;
+            if runtime.can_unload() && state.ctx.is_some() {
+                tracing::info!("model unload timeout expired; unloading model");
+                state.unload_model();
+            }
+        }
+
+        // An active request resets the full timeout when it finishes. An
+        // unloaded model has nothing more to monitor until activity resumes.
+        if receiver.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_human_durations() {
+        assert_eq!("5m".parse(), Ok(UnloadTimeout(Some(Duration::from_secs(300)))));
+        assert_eq!("1h".parse(), Ok(UnloadTimeout(Some(Duration::from_secs(3600)))));
+        assert_eq!("0".parse(), Ok(UnloadTimeout(None)));
+    }
+
+    #[test]
+    fn rejects_zero_and_invalid_durations() {
+        assert!("0s".parse::<UnloadTimeout>().is_err());
+        assert!("never".parse::<UnloadTimeout>().is_err());
+        assert!("later".parse::<UnloadTimeout>().is_err());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn activity_resets_expiration_deadline() {
+        let timeout = Duration::from_secs(300);
+        let deadline = Some(Instant::now() + timeout);
+        let (deadline_tx, mut receiver) = watch::channel(deadline);
+        let runtime = UnloadTimeoutRuntime {
+            timeout: Some(timeout),
+            deadline: deadline_tx,
+            state: Arc::new(StdMutex::new(ActivityState {
+                active_requests: 0,
+                deadline,
+            })),
+        };
+
+        tokio::time::advance(Duration::from_secs(299)).await;
+        let request = runtime.begin_request();
+        let wait = runtime.wait_until_expired(&mut receiver);
+        tokio::pin!(wait);
+        tokio::time::advance(Duration::from_secs(299)).await;
+        assert!(tokio::time::timeout(Duration::ZERO, &mut wait).await.is_err());
+        drop(request);
+        tokio::time::advance(Duration::from_secs(300)).await;
+        assert!(wait.await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn active_request_gets_a_full_timeout_after_completion() {
+        let timeout = Duration::from_secs(300);
+        let deadline = Some(Instant::now() + timeout);
+        let (deadline_tx, _) = watch::channel(deadline);
+        let runtime = UnloadTimeoutRuntime {
+            timeout: Some(timeout),
+            deadline: deadline_tx,
+            state: Arc::new(StdMutex::new(ActivityState {
+                active_requests: 0,
+                deadline,
+            })),
+        };
+        let server_state = Arc::new(Mutex::new(ServerState::new()));
+
+        let lease = runtime.acquire(server_state).await;
+        assert!(runtime.state.lock().expect("timeout state").deadline.is_none());
+        tokio::time::advance(Duration::from_secs(3600)).await;
+        assert!(!runtime.can_unload());
+
+        drop(lease);
+        assert!(runtime.state.lock().expect("timeout state").deadline.is_some());
+        assert!(!runtime.can_unload());
+        tokio::time::advance(Duration::from_secs(299)).await;
+        assert!(!runtime.can_unload());
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(runtime.can_unload());
+    }
+}


### PR DESCRIPTION
## What changed

- Exit Sona when its parent process terminates on Windows as well as Unix.
- Add configurable idle model unloading through `--unload-timeout` / `SONA_UNLOAD_TIMEOUT`.
- Keep active uploads and transcriptions leased so the timeout begins only after work completes.
- Make repeated loads of the same model configuration idempotent.

## Why

Vibe could leave Sona running after exit on Windows, retaining VRAM. Users also need to release model memory after inactivity without stopping the local server.

## Validation

- `cargo test -p sona`
- Manual 20-second timeout test with a transcription lasting 25 seconds; it completed successfully and unloaded only after 20 additional idle seconds.
