### PR TITLE
Run Sortformer diarization on GPU via DirectML on Windows

### DIFF
--- a/crates/diarize-rs/Cargo.toml
+++ b/crates/diarize-rs/Cargo.toml
@@ -11,7 +11,13 @@ name = "diarize_rs"
 path = "src/lib.rs"
 
 [dependencies]
-parakeet-rs = { version = "0.3.2", features = ["sortformer"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+
+# The DirectML execution provider is Windows-only; other platforms stay on CPU.
+[target.'cfg(windows)'.dependencies]
+parakeet-rs = { version = "0.3.6", features = ["sortformer", "directml"] }
+
+[target.'cfg(not(windows))'.dependencies]
+parakeet-rs = { version = "0.3.6", features = ["sortformer"] }
 

--- a/crates/diarize-rs/src/lib.rs
+++ b/crates/diarize-rs/src/lib.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use parakeet_rs::sortformer::{DiarizationConfig, Sortformer};
+use parakeet_rs::ExecutionConfig;
+#[cfg(windows)]
+use parakeet_rs::ExecutionProvider;
 use serde::{Deserialize, Serialize};
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -23,12 +26,15 @@ pub struct Diarizer {
 impl Diarizer {
     pub fn new(model_path: impl AsRef<Path>) -> Result<Self> {
         let path = model_path.as_ref();
-        let sortformer =
-            Sortformer::with_config(path.to_string_lossy().as_ref(), None, DiarizationConfig::callhome())
-                .map_err(|source| Error::Init {
-                    path: path.to_path_buf(),
-                    source: Box::new(source),
-                })?;
+        let sortformer = Sortformer::with_config(
+            path.to_string_lossy().as_ref(),
+            Some(execution_config()),
+            DiarizationConfig::callhome(),
+        )
+        .map_err(|source| Error::Init {
+            path: path.to_path_buf(),
+            source: Box::new(source),
+        })?;
         Ok(Self { sortformer })
     }
 
@@ -52,6 +58,24 @@ impl Diarizer {
             })
             .collect())
     }
+}
+
+/// On Windows, run the Sortformer graph on GPU via DirectML (ort registers a
+/// CPU fallback automatically if the provider is unavailable); set
+/// SONA_DIARIZE_EP=cpu to opt out. Elsewhere, stay on CPU but use all
+/// available cores instead of the crate default of 4.
+fn execution_config() -> ExecutionConfig {
+    let threads = std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(4);
+    let config = ExecutionConfig::new().with_intra_threads(threads);
+    #[cfg(windows)]
+    let config = if std::env::var("SONA_DIARIZE_EP").as_deref() == Ok("cpu") {
+        config
+    } else {
+        config.with_execution_provider(ExecutionProvider::DirectML)
+    };
+    config
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Motivation

Diarization currently runs synchronously before transcription with the parakeet-rs default execution config — CPU with 4 intra-op threads. On long recordings this is a multi-minute silent phase before the first stream event, which surfaces in Vibe as "stuck at 0%" (thewh1teagle/vibe#927 — I reproduced it and this is the root cause; writing a comment with the full diagnosis there).

## What this does

- Enables the `directml` cargo feature of parakeet-rs on Windows (target-gated, other platforms unchanged) and passes an `ExecutionConfig` with `ExecutionProvider::DirectML` instead of `None`.
- DirectML needs no extra runtime dependencies on Windows, and ort registers a CPU fallback automatically, so machines without a usable GPU keep working. `SONA_DIARIZE_EP=cpu` opts out explicitly.
- On non-Windows platforms (and CPU fallback), uses all available cores instead of the crate default of 4 intra-op threads.
- Bumps the parakeet-rs requirement to 0.3.6 (already what Cargo.lock resolves) — the `ExecutionConfig`/`ExecutionProvider` re-exports this patch uses appeared after 0.3.2.

## Measurements

40-minute WAV, Windows 11, RTX 5070 Ti, large-v3-turbo, beam_size 5, `diar_streaming_sortformer_4spk-v2.1.onnx`, transcription on Vulkan in all cases:

| | time to first stream event | total request |
|---|---|---|
| CPU (current main) | 162 s | 186 s |
| DirectML (this PR) | 76 s | 84 s |

Speaker assignments are identical to the CPU baseline on the same inputs (same segment boundaries and labels, including a 2-voice alternating test file).

One packaging note: ort's pyke binary distribution ships a newer `DirectML.dll` next to the built binary; without it, Windows falls back to the System32 copy, which still works but may be older. Worth considering for Vibe's bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)